### PR TITLE
Fixed "scan" target

### DIFF
--- a/src/srclib-typescript.ts
+++ b/src/srclib-typescript.ts
@@ -9,6 +9,11 @@ import depresolve = require('./depresolve');
 
 var program = require('commander');
 
+process.on('uncaughtException', function(e) {
+  console.trace(e);
+  process.exit(1);
+});
+
 program.command("scan").action(function() {new scan.ScanAction().execute()});
 program.
     command("graph").


### PR DESCRIPTION
- when scan downloads packages using "npm install", npm may output installed packages to stdout. Preventing this to avoid malformed JSON passed to srclib
- added uncaught exception handler
